### PR TITLE
consites now selected by closestByPath

### DIFF
--- a/scripts/role.builder.js
+++ b/scripts/role.builder.js
@@ -20,9 +20,10 @@ var roleBuilder = {
             var conSites = creep.room.find(FIND_CONSTRUCTION_SITES);
             //if stuff to build, build it
             if (conSites.length > 0) {
-                conSites.sort(function (a, b) { return a.progress > b.progress ? -1 : 1 });
-                if (creep.build(conSites[0]) == ERR_NOT_IN_RANGE) {
-                    creep.moveTo(conSites[0], { visualizePathStyle: { stroke: '#ffffff' } });
+                //conSites.sort(function (a, b) { return a.progress > b.progress ? -1 : 1 });
+                var targetSite = creep.pos.findClosestByPath(conSites)
+                if (creep.build(targetSite) == ERR_NOT_IN_RANGE) {
+                    creep.moveTo(targetSite, { visualizePathStyle: { stroke: '#ffffff' } });
                 }
             } else {
                 //if nothing to build, repair


### PR DESCRIPTION
I think I like this better already so I'm going to merge it to master - construction sites are now prioritized by whatever is closest to that builder creep, as are the energy storage they pull from so it should minimize travel. If this becomes a problem with needing to prioritize particular structure types, I could either hard code in an array that if it's empty it defaults back to this or do some type of chained logic by structure type but I'm not sure that's really necessary at the rate I build....